### PR TITLE
fix: remove unnecessary literals

### DIFF
--- a/refactor/urls.js
+++ b/refactor/urls.js
@@ -1,0 +1,10 @@
+function getURL(dev = false, tasks = {}) {
+    let url = dev
+        ? '/tasks?status=ACTIVE&dev=true&size=20'
+        : '/tasks';
+
+    if (tasks.nextTasks) url += '?hasNext=true';
+    if (tasks.prevTasks) url = '/tasks?hasPrev=true';
+
+    return { url };
+}


### PR DESCRIPTION
Removed unnecessary template literals where not needed.

Simplified if blocks to single-line statements without changing logic.